### PR TITLE
fix: Unpin button in Sleep Image Picker now actually unpins

### DIFF
--- a/src/activities/tools/SleepImagePickerActivity.cpp
+++ b/src/activities/tools/SleepImagePickerActivity.cpp
@@ -314,8 +314,13 @@ void SleepImagePickerActivity::loop() {
   }
 
   const int items = totalItems();
-  buttonNavigator.onNext([this, items] { selectorIndex = ButtonNavigator::nextIndex(selectorIndex, items); requestUpdate(); });
-  buttonNavigator.onPrevious([this, items] { selectorIndex = ButtonNavigator::previousIndex(selectorIndex, items); requestUpdate(); });
+  // Bind Up/Down explicitly (not via onNext/onPrevious) so Left/Right stay free
+  // for the Pin/Unpin handler below — otherwise Left's button-down would move
+  // the cursor before wasReleased(Left) reads selectorIndex.
+  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Down},
+    [this, items] { selectorIndex = ButtonNavigator::nextIndex(selectorIndex, items); requestUpdate(); });
+  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up},
+    [this, items] { selectorIndex = ButtonNavigator::previousIndex(selectorIndex, items); requestUpdate(); });
 
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     if (selectorIndex == MODE_ITEM) {


### PR DESCRIPTION
## Summary

Fix the Unpin button in the Sleep Image Picker — pressing Left on a pinned image was moving thecursor up and pinning the row above, instead of clearing the pin.

* **What changes are included?**
    - `src/activities/tools/SleepImagePickerActivity.cpp` — in list mode, bind Up/Down explicitly via `onPressAndContinuous({Up})` /`({Down})` instead of `onNext`/`onPrevious`, so Left/Right are no longer consumed by `ButtonNavigator`'s "previous/next" actions.

## Additional Context

Root cause is a button-down vs button-up race:

  - `buttonNavigator.onPrevious(...)` binds the callback to `{Up, Left}` on **button-down** (`ButtonNavigator::getPreviousButtons()`), and on Left it moves `selectorIndex` up.
  - The explicit `wasReleased(Left)` handler then reads `selectorIndex` on **button-up** to decide Pin vs Unpin via
  `isCurrentImageSelection(selectorIndex)`.

So pressing Left on a pinned row first moved the selector to the row above, then the release handler saw it was no longer on the pinned row and took the else branch — pinning that new row. The original pin was never cleared.

Slideshow mode is untouched (Left = previous image is the right semantic there).

Tested on-device — pin/unpin now works correctly, Up/Down navigation still works, slideshow Left/Right still navigates images.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
